### PR TITLE
Deprecated variants CSS edits

### DIFF
--- a/scripts/generatePagesFromConsolidatedJSON.py
+++ b/scripts/generatePagesFromConsolidatedJSON.py
@@ -399,7 +399,11 @@ def generateAllPages(pathPages,paper):
        <div id="tabs">
           <ul>''')
  for varid, var in enumerate(paper):
-    f.write("             <li><a href=\"#review-%d\">%s</a></li>\n" % (varid+1, var['Variant name']))
+    if var['Is variant deprecated (boolean)']==False:
+        f.write("             <li><a href=\"#review-%d\">%s</a></li>\n" % (varid+1, var['Variant name']))
+    else:
+        f.write("             <li><a style='color:gray;text-decoration:line-through;' href=\"#review-%d\">%s</a></li>\n" % (varid+1, var['Variant name']))
+  
  f.write("             <li><a href=\"#review-%s\">&#43;</a></li>\n" % (len(paper)+1))
  f.write("</ul>")
 


### PR DESCRIPTION
Tab name for deprecated variants: gray + strikeout

![Capture d’écran 2020-05-03 à 09 15 33](https://user-images.githubusercontent.com/700165/80908245-a8474600-8d1e-11ea-9121-8614a8b95473.png)
