### PR TITLE
Fixes #154

### DIFF
--- a/scripts/generatePagesFromConsolidatedJSON.py
+++ b/scripts/generatePagesFromConsolidatedJSON.py
@@ -1096,14 +1096,14 @@ with open(sys.argv[1]) as json_file:
               fbrowse.write("<td>"+ hasPseudoCode+"</td>")
               #Pseudo score
               pscore = variant['If pseudo-code, could the paper be trivially implemented? {0..4}']
-	      if hasPseudoCode==True:
+              if hasPseudoCode==True:
                   if ( pscore != ''):
                       if( pscore >= 4 ) :
                           step2dataYear[5] = step2dataYear[5] + 1
                       else :
                           step2dataYear[6] = step2dataYear[6] + 1
-		  else:
-		      print( "[WARNING] Inconsistent choice for pseudo-code availability and score [ https://replicability.graphics/papers/" + doiclean+"/index.html  "+ variant['DOI'] + "]" )
+                  else:
+                      print( "[WARNING] Inconsistent choice for pseudo-code availability and score [ https://replicability.graphics/papers/" + doiclean+"/index.html  "+ variant['DOI'] + "]" )
               fbrowse.write("<td>"+str(pscore)+"</td>")
               #Doc score
               fbrowse.write("<td>"+str(variant['Documentation score {0=NA,1,2,3}'])+"</td>")

--- a/scripts/generatePagesFromConsolidatedJSON.py
+++ b/scripts/generatePagesFromConsolidatedJSON.py
@@ -1103,7 +1103,7 @@ with open(sys.argv[1]) as json_file:
                       else :
                           step2dataYear[6] = step2dataYear[6] + 1
                   else:
-                      print( "[WARNING] Inconsistent choice for pseudo-code availability and score [ https://replicability.graphics/papers/" + doiclean+"/index.html  "+ variant['DOI'] + "]" )
+                      print( "[WARNING] Inconsistent choice for pseudo-code availability and score  (the paper has a pseudo-code but an empty pseudo-code score) [ https://replicability.graphics/papers/" + doiclean+"/index.html  "+ variant['DOI'] + "]" )
               fbrowse.write("<td>"+str(pscore)+"</td>")
               #Doc score
               fbrowse.write("<td>"+str(variant['Documentation score {0=NA,1,2,3}'])+"</td>")

--- a/scripts/generatePagesFromConsolidatedJSON.py
+++ b/scripts/generatePagesFromConsolidatedJSON.py
@@ -1096,13 +1096,14 @@ with open(sys.argv[1]) as json_file:
               fbrowse.write("<td>"+ hasPseudoCode+"</td>")
               #Pseudo score
               pscore = variant['If pseudo-code, could the paper be trivially implemented? {0..4}']
-              if ( pscore != ''):
-                  if (not variant["If code not available, pseudo-code available (boolean)"]):
-                       print( "[WARNING] Inconsistent choice for pseudo-code availability and score [ https://replicability.graphics/papers/" + doiclean+"/index.html  "+ variant['DOI'] + "]" )
-                  if( pscore >= 4 ) :
-                      step2dataYear[5] = step2dataYear[5] + 1
-                  else :
-                      step2dataYear[6] = step2dataYear[6] + 1
+	      if hasPseudoCode==True:
+                  if ( pscore != ''):
+                      if( pscore >= 4 ) :
+                          step2dataYear[5] = step2dataYear[5] + 1
+                      else :
+                          step2dataYear[6] = step2dataYear[6] + 1
+		  else:
+		      print( "[WARNING] Inconsistent choice for pseudo-code availability and score [ https://replicability.graphics/papers/" + doiclean+"/index.html  "+ variant['DOI'] + "]" )
               fbrowse.write("<td>"+str(pscore)+"</td>")
               #Doc score
               fbrowse.write("<td>"+str(variant['Documentation score {0=NA,1,2,3}'])+"</td>")


### PR DESCRIPTION
Fixes issue #154 

The error is caused by a change of logic in the json files: this script expects an empty field for `pseudocode score` when there is no pseudocode.
See warnings in error log: https://github.com/GraphicsReplicability/replicability.graphics/runs/898876115?check_suite_focus=true#step:3:761

Fix: Check only the pseudocode state when pseudocode is available.

